### PR TITLE
Fixed link to rubric and added link for getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 frontend-nanodegree-arcade-game
 ===============================
 
-Students should use this rubric: https://www.udacity.com/course/viewer#!/c-ud015/l-3072058665/m-3072588797
+Students should use this [rubric](https://www.udacity.com/course/viewer/#!/c-nd001/l-2696458597/m-2687128535) for self-checking their submission.
 
-for self-checking their submission.
+For detailed instructions on how to get started, check out this [guide](https://docs.google.com/document/d/1v01aScPjSWCCWQLIpFqvg3-vXLH2e8_SZQKC8jNO0Dc/pub).


### PR DESCRIPTION
Hi there - it looks like the link to the rubric was broken, so I linked it to the current page that has the rubric for the frontend nanodegree.  I also added the getting started guide for the students' convenience.  Let me know if this is okay!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/frontend-nanodegree-arcade-game/19)
<!-- Reviewable:end -->
